### PR TITLE
Add docker image info to GitHub Actions log

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
             C_COMPILER_NAME=${{matrix.compiler.c}}
             CPP_COMPILER_NAME=${{matrix.compiler.cpp}}
           push: false
+          load: true
       - name: Login into registry
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v1.4.1
@@ -62,3 +63,10 @@ jobs:
             C_COMPILER_NAME=${{matrix.compiler.c}}
             CPP_COMPILER_NAME=${{matrix.compiler.cpp}}
           push: true
+          load: true
+      - name: Report image details
+        run: >
+          docker image history
+          --no-trunc
+          --format "table {{.Size}}\t{{.CreatedBy}}"
+          ${{steps.info.outputs.tag}}


### PR DESCRIPTION
Will help us figure out where the images size comes from.