### PR TITLE
Move docker size report to pull request only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,13 @@ jobs:
             CPP_COMPILER_NAME=${{matrix.compiler.cpp}}
           push: false
           load: true
+      - name: Report image details
+        if: github.ref != 'refs/heads/main'
+        run: >
+          docker image history
+          --no-trunc
+          --format "table {{.Size}}\t{{.CreatedBy}}"
+          ${{steps.info.outputs.tag}}
       - name: Login into registry
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v1.4.1
@@ -63,10 +70,3 @@ jobs:
             C_COMPILER_NAME=${{matrix.compiler.c}}
             CPP_COMPILER_NAME=${{matrix.compiler.cpp}}
           push: true
-          load: true
-      - name: Report image details
-        run: >
-          docker image history
-          --no-trunc
-          --format "table {{.Size}}\t{{.CreatedBy}}"
-          ${{steps.info.outputs.tag}}


### PR DESCRIPTION
Docker buildx works differently than standard docker. We can't use docker history the same way.