### PR TITLE
Add license auto update

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,0 +1,72 @@
+name: Update license
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/update-license.yml
+  schedule:
+    - cron: '0 0 1 1 *'
+env:
+  BRANCH: auto/update-license
+jobs:
+  update-license:
+    name: Update license
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      - name: Create/switch to ${{env.BRANCH}}
+        run: |
+          git fetch origin +refs/heads/$BRANCH:refs/heads/$BRANCH || true  
+          git checkout $BRANCH || git checkout -b $BRANCH
+      - name: Update license
+        run: |
+          sed -i -E "s/^(Copyright.*)[0-9]{4}(.*)$/\1$(date +%Y)\2/" LICENSE
+      - name: Check for changes
+        id: changes
+        run: |
+          git diff --exit-code LICENSE || echo "::set-output name=exist::true"
+      - name: Create commit
+        if: steps.changes.outputs.exist
+        run: |
+          git reset --hard origin/main
+          DATE=$(date +%Y)
+          sed -i -E "s/^(Copyright.*)[0-9]{4}(.*)$/\1$DATE\2/" LICENSE
+          git config user.name $COMMIT_USERNAME
+          git config user.email $COMMIT_EMAIL
+          git add LICENSE
+          git commit -m "Update license year"
+          git push --force origin $BRANCH
+        env:
+          COMMIT_USERNAME: ${{secrets.UPDATE_LICENSE_USER}}
+          COMMIT_EMAIL: ${{secrets.UPDATE_LICENSE_EMAIL}}
+      - name: Create pull request
+        if: steps.changes.outputs.exist
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            const owner = '${{github.repository_owner}}';
+            const repo = 'DockerBuildLinux';
+            const base = 'refs/heads/main';
+            const head = 'refs/heads/${{env.BRANCH}}';
+            const pullRequests = await github.pulls.list({
+                head: `${owner}:${head}`,
+                owner, repo, base
+            });
+            if (pullRequests.data.length === 0) {
+                const createResult = await github.pulls.create({
+                    title: 'Update license year',
+                    owner, repo, head, base
+                });
+                github.issues.addLabels({
+                    issue_number: createResult.data.number,
+                    owner, repo, labels: ['auto']
+                });
+                console.log('Created new pull request');
+                return createResult.data.number;
+            } else {
+                console.log('Pull request already exists');
+            }
+          result-encoding: string
+          github-token: ${{secrets.UPDATE_LICENSE_TOKEN}}


### PR DESCRIPTION
This will run once a year on January 1st or whenever the script is modified. It will update the year in the main `LICENSE` file and open a pull request. If this works I think the same concept can be expanded to update more then just the `LICENSE` file.