### PR TITLE
Try updating to more recent compilers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           - packages: gcc-10 g++-10
             c: gcc-10
             cpp: g++-10
+          - packages: gcc-11 g++-11
+            c: gcc-11
+            cpp: g++-11            
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           - packages: clang-12
             c: clang-12
             cpp: clang++-12
-          - packages: gcc-10 g++-9
+          - packages: gcc-9 g++-9
             c: gcc-9
             cpp: g++-9
-          - packages: gcc-11 g++-10
+          - packages: gcc-10 g++-10
             c: gcc-10
             cpp: g++-10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
     strategy:
       matrix:
         compiler:
+          - packages: clang-9
+            c: clang-9
+            cpp: clang++-9
+          - packages: clang-10
+            c: clang-10
+            cpp: clang++-10        
           - packages: clang-11
             c: clang-11
             cpp: clang++-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
           - packages: clang-12
             c: clang-12
             cpp: clang++-12
-          - packages: gcc-10 g++-10
+          - packages: gcc-10 g++-9
+            c: gcc-9
+            cpp: g++-9
+          - packages: gcc-11 g++-10
             c: gcc-10
             cpp: g++-10
-          - packages: gcc-11 g++-11
-            c: gcc-11
-            cpp: g++-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,18 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - packages: clang-9
-            c: clang-9
-            cpp: clang++-9
-          - packages: clang-10
-            c: clang-10
-            cpp: clang++-10
-          - packages: gcc-9 g++-9
-            c: gcc-9
-            cpp: g++-9
+          - packages: clang-11
+            c: clang-11
+            cpp: clang++-11
+          - packages: clang-12
+            c: clang-12
+            cpp: clang++-12
           - packages: gcc-10 g++-10
             c: gcc-10
             cpp: g++-10
+          - packages: gcc-11 g++-11
+            c: gcc-11
+            cpp: g++-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ ENV PATH="${PATH}:${HOME}/.cargo/bin"
 RUN export DEBIAN_FRONTEND='noninteractive' && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y \
-      ${COMPILER_PACKAGES} \
+    apt-get install --no-install-recommends --no-install-suggests -y \
       apt-utils \
+      software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    apt-get install --no-install-recommends --no-install-suggests -y \
+      ${COMPILER_PACKAGES} \
       ca-certificates \
       cmake=${CMAKE_VERSION}* \
       curl \
@@ -28,8 +31,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
       make \
       ninja-build \
       pkg-config \
-      python3 \
-      software-properties-common && \
+      python3 && \
     update-alternatives --install \
       /usr/bin/cc cc /usr/bin/${C_COMPILER_NAME} 100 && \
     update-alternatives --install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     apt-get install --no-install-recommends --no-install-suggests -y \
       apt-utils \
       software-properties-common && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
     apt-get install --no-install-recommends --no-install-suggests -y \
       ${COMPILER_PACKAGES} \
       ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
       make \
       ninja-build \
       pkg-config \
-      python3 && \
+      python3 \
+      software-properties-common && \
     update-alternatives --install \
       /usr/bin/cc cc /usr/bin/${C_COMPILER_NAME} 100 && \
     update-alternatives --install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,6 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
 CMD ["bash"]
 
 # labels
-LABEL maintainer WNProject
-LABEL org.opencontainers.image.source \
-      https://github.com/WNProject/DockerBuildLinux
+LABEL maintainer WNProject \
+      org.opencontainers.image.source \
+        https://github.com/WNProject/DockerBuildLinux

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ docker build . -t build-linux \
     --build-arg CPP_COMPILER_NAME='[clang++*|g++*]'
 ```
 
-Currently only version `9` and `10` of **GCC** and `9`, `10`, `11` and `12` of
-**Clang** are supported.
+Currently only version `9`, `10` and `11` of **GCC** and `9`, `10`, `11` and
+`12` of **Clang** are supported.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ docker build . -t build-linux \
     --build-arg CPP_COMPILER_NAME='[clang++*|g++*]'
 ```
 
-Currently only version `9` and `10` of both **GCC** and **Clang** are supported.
+Currently only version `9` and `10` of **GCC** and `9`, `10`, `11` and `12` of
+**Clang** are supported.
 
 ### Example
 


### PR DESCRIPTION
This add builds for `clang-11`, `clang-12` and `gcc-11`. Want to look at abandoning `gcc-9` and `clang-10` eventually.